### PR TITLE
YAML specification for ledger_entry request

### DIFF
--- a/async_api/requests/ledger_entry_async_api.yaml
+++ b/async_api/requests/ledger_entry_async_api.yaml
@@ -1,0 +1,84 @@
+components:
+  schemas:
+    LedgerEntryRequest:
+      $id: LedgerEntryRequest
+      type: object
+      description: >
+        The ledger_entry method returns a single ledger entry from the XRP Ledger in its raw format.
+        All information retrieved is relative to a particular version of the ledger.
+        Returns a LedgerEntryResponse.
+      allOf:
+        - $ref: '../../shared/requests/ledger_entry.yaml#/components/schemas/LedgerEntryRequest'
+        - type: object
+          properties:
+            command:
+              $ref: '../../shared/base.yaml#/components/schemas/CommandTypes'
+            id:
+              description: 'A unique identifier for the request.'
+      required:
+        - command
+        - id
+      example:
+        id: 3
+        command: ledger_entry
+        index: '13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8'
+        ledger_index: 'validated'
+
+    LedgerEntryResponse:
+      $id: LedgerEntryResponse
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/LedgerEntrySuccessResponse'
+        - $ref: '#/components/schemas/LedgerEntryErrorResponse'
+      properties:
+        id:
+          description: 'A unique identifier for the request.'
+        type:
+          type: string
+          description: The value response indicates a direct response to an API request. Asynchronous notifications use a different value such as `ledgerClosed` or `transaction`.
+          enum:
+            - response
+      required:
+        - id
+        - type
+      example:
+        id: 3
+        status: success
+        type: response
+        result:
+          index: '13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8'
+          ledger_index: 54321
+          node:
+            Account: 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn'
+            Balance: '148446663'
+            Flags: 8388608
+            LedgerEntryType: 'AccountRoot'
+            OwnerCount: 3
+            PreviousTxnID: '13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8'
+            PreviousTxnLgrSeq: 54320
+            Sequence: 336
+
+    LedgerEntryErrorResponse:
+      $id: LedgerEntryErrorResponse
+      oneOf:
+        - $ref: '../../shared/base.yaml#/components/schemas/WebsocketErrorFields'
+        - $ref: '../../shared/requests/ledger_entry.yaml#/components/schemas/LedgerEntryErrorResponse'
+      properties:
+        status:
+          type: string
+          enum:
+            - error
+
+    LedgerEntrySuccessResponse:
+      $id: LedgerEntrySuccessResponse
+      properties:
+        result:
+          type: object
+          allOf:
+            - $ref: '../../shared/requests/ledger_entry.yaml#/components/schemas/LedgerEntrySuccessResponse'
+        status:
+          type: string
+          enum:
+            - success
+      required:
+        - status

--- a/async_api/websocket_api.yaml
+++ b/async_api/websocket_api.yaml
@@ -54,6 +54,7 @@ channels:
           - $ref: '#/components/messages/AccountChannelsRequest'
           - $ref: '#/components/messages/AccountInfoRequest'
           - $ref: '#/components/messages/AccountLinesRequest'
+          - $ref: '#/components/messages/LedgerEntryRequest'
           # ... (Add references for additional requests)
     publish:
       operationId: publishToRoot
@@ -62,6 +63,7 @@ channels:
           - $ref: '#/components/messages/AccountChannelsResponse'
           - $ref: '#/components/messages/AccountInfoResponseV1'
           - $ref: '#/components/messages/AccountLinesResponse'
+          - $ref: '#/components/messages/LedgerEntryResponse'
           # ... (Add references for additional responses)
 
 # Moved message definitions to a separate components section
@@ -91,6 +93,14 @@ components:
       payload:
         $ref: './requests/account_lines_async_api.yaml#/components/schemas/AccountLinesRequest'
 
+    # Ledger entry request message
+    LedgerEntryRequest:
+      name: LedgerEntryRequest
+      messageId: LedgerEntryRequest
+      contentType: application/json
+      payload:
+        $ref: './requests/ledger_entry_async_api.yaml#/components/schemas/LedgerEntryRequest'
+
     # ... (Add definitions for additional message types)
 
     # Account channels response message
@@ -116,4 +126,12 @@ components:
       contentType: application/json
       payload:
         $ref: './requests/account_lines_async_api.yaml#/components/schemas/AccountLinesResponse'
+
+    # Ledger entry response message
+    LedgerEntryResponse:
+      name: LedgerEntryResponse
+      messageId: LedgerEntryResponse
+      contentType: application/json
+      payload:
+        $ref: './requests/ledger_entry_async_api.yaml#/components/schemas/LedgerEntryResponse'
     # ... (Add definitions for additional response types)

--- a/async_api/websocket_api_v2.yaml
+++ b/async_api/websocket_api_v2.yaml
@@ -63,6 +63,11 @@ channels:
             contentType: application/json
             payload:
               $ref: './requests/account_lines_async_api.yaml#/components/schemas/AccountLinesRequest'
+          - name: LedgerEntryRequest
+            messageId: LedgerEntryRequest
+            contentType: application/json
+            payload:
+              $ref: './requests/ledger_entry_async_api.yaml#/components/schemas/LedgerEntryRequest'
           # TODO: Add additional request types for individual requests here
     publish:
       operationId: publishToRoot
@@ -83,4 +88,9 @@ channels:
             contentType: application/json
             payload:
               $ref: './requests/account_lines_async_api.yaml#/components/schemas/AccountLinesResponse'
+          - name: LedgerEntryResponse
+            messageId: LedgerEntryResponse
+            contentType: application/json
+            payload:
+              $ref: './requests/ledger_entry_async_api.yaml#/components/schemas/LedgerEntryResponse'
           # TODO: Add additional response types for individual requests here

--- a/open_api/json_api.yaml
+++ b/open_api/json_api.yaml
@@ -35,12 +35,14 @@ paths:
                   account_info: 'requests/account_info_open_api.yaml#/components/schemas/AccountInfoRequest'
                   account_lines: 'requests/account_lines_open_api.yaml#/components/schemas/AccountLinesRequest'
                   submit: 'requests/submit_open_api.yaml#/components/schemas/SubmitRequestV1'
+                  ledger_entry: 'requests/ledger_entry_open_api.yaml#/components/schemas/LedgerEntryRequest'
                   # TODO: Add the rest of the JSON RPC requests here
               oneOf:
                 - $ref: 'requests/account_channels_open_api.yaml#/components/schemas/AccountChannelsRequest'
                 - $ref: 'requests/account_info_open_api.yaml#/components/schemas/AccountInfoRequest'
                 - $ref: 'requests/account_lines_open_api.yaml#/components/schemas/AccountLinesRequest'
                 - $ref: 'requests/submit_open_api.yaml#/components/schemas/SubmitRequestV1'
+                - $ref: 'requests/ledger_entry_open_api.yaml#/components/schemas/LedgerEntryRequest'
                 # TODO: Add the rest of the JSON RPC requests here
         required: true
       operationId: 'POST'
@@ -61,6 +63,7 @@ paths:
                   - $ref: 'requests/account_info_open_api.yaml#/components/schemas/AccountInfoResponseV1'
                   - $ref: 'requests/submit_open_api.yaml#/components/schemas/SubmitResponseV1'
                   - $ref: 'requests/account_lines_open_api.yaml#/components/schemas/AccountLinesResponse'
+                  - $ref: 'requests/ledger_entry_open_api.yaml#/components/schemas/LedgerEntryResponse'
                   # TODO: Add the rest of the JSON RPC responses here
 
         # TODO: We want to be much more explicit with http error codes for a full implementation of this spec.

--- a/open_api/json_api_v2.yaml
+++ b/open_api/json_api_v2.yaml
@@ -33,12 +33,14 @@ paths:
                   account_info: 'requests/account_info_open_api.yaml#/components/schemas/AccountInfoRequest'
                   submit: 'requests/submit_open_api.yaml#/components/schemas/SubmitRequestV2'
                   account_lines: 'requests/account_lines_open_api.yaml#/components/schemas/AccountLinesRequest'
+                  ledger_entry: 'requests/ledger_entry_open_api.yaml#/components/schemas/LedgerEntryRequest'
                   # TODO: Add the rest of the JSON RPC requests here
               oneOf:
                 - $ref: 'requests/account_channels_open_api.yaml#/components/schemas/AccountChannelsRequest'
                 - $ref: 'requests/account_info_open_api.yaml#/components/schemas/AccountInfoRequest'
                 - $ref: 'requests/submit_open_api.yaml#/components/schemas/SubmitRequestV2'
                 - $ref: 'requests/account_lines_open_api.yaml#/components/schemas/AccountLinesRequest'
+                - $ref: 'requests/ledger_entry_open_api.yaml#/components/schemas/LedgerEntryRequest'
                 # TODO: Add the rest of the JSON RPC requests here
         required: true
       operationId: 'POST'
@@ -53,6 +55,7 @@ paths:
                   - $ref: 'requests/account_info_open_api.yaml#/components/schemas/AccountInfoResponseV2'
                   - $ref: 'requests/submit_open_api.yaml#/components/schemas/SubmitResponseV2'
                   - $ref: 'requests/account_lines_open_api.yaml#/components/schemas/AccountLinesResponse'
+                  - $ref: 'requests/ledger_entry_open_api.yaml#/components/schemas/LedgerEntryResponse'
                   # TODO: Add the rest of the JSON RPC responses here
 
         # TODO: We want to be much more explicit with http error codes for a full implementation of this spec.

--- a/open_api/requests/ledger_entry_open_api.yaml
+++ b/open_api/requests/ledger_entry_open_api.yaml
@@ -1,0 +1,55 @@
+components:
+  schemas:
+    LedgerEntryRequest:
+      type: object
+      description: >
+        The ledger_entry method returns a single ledger entry from the XRP Ledger in its raw format.
+        All information retrieved is relative to a particular version of the ledger.
+        Returns a LedgerEntryResponse.
+      properties:
+        method:
+          type: string
+          enum:
+            - ledger_entry
+        params:
+          type: array
+          items:
+            $ref: '../../shared/requests/ledger_entry.yaml#/components/schemas/LedgerEntryRequest'
+      required:
+        - method
+      example:
+        method: 'ledger_entry'
+        params:
+          - ledger_index: 'validated'
+            binary: false
+            index: '13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8'
+
+    LedgerEntryResponse:
+      type: object
+      properties:
+        result:
+          type: object
+          discriminator:
+            propertyName: status
+            mapping:
+              success: '../../shared/requests/ledger_entry.yaml#/components/schemas/LedgerEntrySuccessResponse'
+              error: '../../shared/requests/ledger_entry.yaml#/components/schemas/LedgerEntryErrorResponse'
+          oneOf:
+            - $ref: '../../shared/requests/ledger_entry.yaml#/components/schemas/LedgerEntrySuccessResponse'
+            - $ref: '../../shared/requests/ledger_entry.yaml#/components/schemas/LedgerEntryErrorResponse'
+      required:
+        - result
+      example:
+        result:
+          index: '13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8'
+          ledger_index: 54321
+          node:
+            Account: 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn'
+            Balance: '148446663'
+            Flags: 8388608
+            LedgerEntryType: 'AccountRoot'
+            OwnerCount: 3
+            PreviousTxnID: '13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8'
+            PreviousTxnLgrSeq: 54320
+            Sequence: 336
+          status: 'success'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "rippled-api-sec",
+  "name": "rippled-api-spec",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -9,7 +9,7 @@
         "@redocly/realm": "^0.86.4"
       },
       "devDependencies": {
-        "@apidevtools/json-schema-ref-parser": "^11.6.4",
+        "@apidevtools/json-schema-ref-parser": "^11.7.0",
         "prettier": "3.2.5"
       }
     },
@@ -26,9 +26,9 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.6.4",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.4.tgz",
-      "integrity": "sha512-9K6xOqeevacvweLGik6LnZCb1fBtCOSIWQs8d096XGeqoLKC33UVMGz9+77Gw44KvbH4pKcQPWo4ZpxkXYj05w==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.0.tgz",
+      "integrity": "sha512-pRrmXMCwnmrkS3MLgAIW5dXRzeTv6GLjkjb4HmxNnvAKXN1Nfzp4KmGADBQvlVUcqi+a5D+hfGDLLnd5NnYxog==",
       "dev": true,
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
@@ -11507,9 +11507,9 @@
       }
     },
     "@apidevtools/json-schema-ref-parser": {
-      "version": "11.6.4",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.4.tgz",
-      "integrity": "sha512-9K6xOqeevacvweLGik6LnZCb1fBtCOSIWQs8d096XGeqoLKC33UVMGz9+77Gw44KvbH4pKcQPWo4ZpxkXYj05w==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.0.tgz",
+      "integrity": "sha512-pRrmXMCwnmrkS3MLgAIW5dXRzeTv6GLjkjb4HmxNnvAKXN1Nfzp4KmGADBQvlVUcqi+a5D+hfGDLLnd5NnYxog==",
       "dev": true,
       "requires": {
         "@jsdevtools/ono": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "bundle": "redocly bundle open_api/json_api.yaml --output dist/openapi && node generate-specs.js"
   },
   "devDependencies": {
-    "@apidevtools/json-schema-ref-parser": "^11.6.4",
+    "@apidevtools/json-schema-ref-parser": "^11.7.0",
     "prettier": "3.2.5"
   },
   "dependencies": {

--- a/shared/base.yaml
+++ b/shared/base.yaml
@@ -190,3 +190,14 @@ components:
         issuer:
           type: string
           description: 'Generally, the account that issues this token. In special cases, this can refer to the account that holds the token instead (for example, in a Clawback transaction).'
+
+    CurrencyWithoutAmount:
+      $id: CurrencyWithoutAmount
+      type: object
+      properties:
+        currency:
+          type: string
+          description: 'Arbitrary currency code for the token.'
+        issuer:
+          type: string
+          description: 'Generally, the account that issues this token. In special cases, this can refer to the account that holds the token instead (for example, in a Clawback transaction).'

--- a/shared/requests/ledger_entry.yaml
+++ b/shared/requests/ledger_entry.yaml
@@ -1,0 +1,277 @@
+components:
+  schemas:
+    BaseLedgerEntryRequest:
+      type: object
+      properties:
+        binary:
+          type: boolean
+          description: (Optional) If true, return the requested ledger entry's contents as a hex string in the XRP Ledger's binary format. Otherwise, return data in JSON format. The default is false.
+        include_deleted:
+          type: boolean
+          description: (Optional, Clio servers only) If set to true and the queried object has been deleted, return its complete data as it was prior to its deletion. If set to false or not provided, and the queried object has been deleted, return objectNotFound (current behavior).
+
+    LedgerEntryRequestOptions:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/LedgerEntryByID'
+        - $ref: '#/components/schemas/AccountRootEntry'
+        - $ref: '#/components/schemas/AMMEntry'
+        - $ref: '#/components/schemas/BridgeEntry'
+        - $ref: '#/components/schemas/DirectoryNodeEntry'
+        - $ref: '#/components/schemas/OfferEntry'
+        - $ref: '#/components/schemas/OracleEntry'
+        - $ref: '#/components/schemas/RippleStateEntry'
+        - $ref: '#/components/schemas/CheckEntry'
+        - $ref: '#/components/schemas/EscrowEntry'
+        - $ref: '#/components/schemas/PayChannelEntry'
+        - $ref: '#/components/schemas/DepositPreauthEntry'
+        - $ref: '#/components/schemas/TicketEntry'
+        - $ref: '#/components/schemas/NFTPageEntry'
+
+    # Ledger entry request message
+    LedgerEntryRequest:
+      summary: >
+        The ledger_entry method returns a single ledger entry from the XRP Ledger in its raw format.
+        All information retrieved is relative to a particular version of the ledger.
+        Returns a LedgerEntryResponse
+      description: The ledger_entry method returns a single ledger entry from the XRP Ledger in its raw format. All information retrieved is relative to a particular version of the ledger.
+      type: object
+      allOf:
+        - $ref: '../base.yaml#/components/schemas/LookupByLedgerRequest'
+        - $ref: '../base.yaml#/components/schemas/BaseRequest'
+        - $ref: '#/components/schemas/BaseLedgerEntryRequest'
+        - $ref: '#/components/schemas/LedgerEntryRequestOptions'
+
+    LedgerEntryByID:
+      type: object
+      description: Retrieve any type of ledger object by its unique ID.
+      properties:
+        index:
+          type: string
+          description: The ledger entry ID of a single entry to retrieve from the ledger, as a 64-character (256-bit) hexadecimal string.
+
+    AccountRootEntry:
+      type: object
+      description: Retrieve an AccountRoot entry by its address. This is roughly equivalent to the account_info method.
+      properties:
+        account_root:
+          type: string
+          description: The classic address of the AccountRoot entry to retrieve.
+
+    AMMEntry:
+      type: object
+      description: Retrieve an Automated Market-Maker (AMM) object from the ledger. This is similar to amm_info method, but the ledger_entry version returns only the ledger entry as stored.
+      properties:
+        amm:
+          oneOf:
+            - type: string
+            - type: object
+              properties:
+                asset:
+                  $ref: '../base.yaml#/components/schemas/CurrencyWithoutAmount'
+                asset2:
+                  $ref: '../base.yaml#/components/schemas/CurrencyWithoutAmount'
+
+    BridgeEntry:
+      type: object
+      description: Retrieve a Bridge entry, which represents a single cross-chain bridge that connects the XRP Ledger with another blockchain.
+      properties:
+        bridge_account:
+          type: string
+          description: The account that submitted the XChainCreateBridge transaction on the blockchain.
+        bridge:
+          type: object
+          properties:
+            IssuingChainDoor:
+              type: string
+            IssuingChainIssue:
+              $ref: '../base.yaml#/components/schemas/CurrencyWithoutAmount'
+            LockingChainDoor:
+              type: string
+            LockingChainIssue:
+              $ref: '../base.yaml#/components/schemas/CurrencyWithoutAmount'
+
+    DirectoryNodeEntry:
+      type: object
+      description: Retrieve a DirectoryNode, which contains a list of other ledger objects.
+      properties:
+        directory:
+          oneOf:
+            - type: string
+            - type: object
+              properties:
+                sub_index:
+                  type: integer
+                dir_root:
+                  type: string
+                owner:
+                  type: string
+
+    OfferEntry:
+      type: object
+      description: Retrieve an Offer entry, which defines an offer to exchange currency.
+      properties:
+        offer:
+          oneOf:
+            - type: string
+            - type: object
+              properties:
+                account:
+                  type: string
+                seq:
+                  type: integer
+
+    OracleEntry:
+      type: object
+      description: Retrieve an Oracle entry, which represents a single price oracle that can store token prices.
+      properties:
+        oracle:
+          type: object
+          properties:
+            account:
+              type: string
+            oracle_document_id:
+              type: integer
+
+    RippleStateEntry:
+      type: object
+      description: Retrieve a RippleState entry, which tracks a (non-XRP) currency balance between two accounts.
+      properties:
+        ripple_state:
+          type: object
+          properties:
+            accounts:
+              type: array
+              items:
+                type: string
+              minItems: 2
+              maxItems: 2
+            currency:
+              type: string
+
+    CheckEntry:
+      type: object
+      description: Retrieve a Check entry, which is a potential payment that can be cashed by its recipient.
+      properties:
+        check:
+          type: string
+
+    EscrowEntry:
+      type: object
+      description: Retrieve an Escrow entry, which holds XRP until a specific time or condition is met.
+      properties:
+        escrow:
+          oneOf:
+            - type: string
+            - type: object
+              properties:
+                owner:
+                  type: string
+                seq:
+                  type: integer
+
+    PayChannelEntry:
+      type: object
+      description: Retrieve a PayChannel entry, which holds XRP for asynchronous payments.
+      properties:
+        payment_channel:
+          type: string
+
+    DepositPreauthEntry:
+      type: object
+      description: Retrieve a DepositPreauth entry, which tracks preauthorization for payments to accounts requiring Deposit Authorization.
+      properties:
+        deposit_preauth:
+          oneOf:
+            - type: string
+            - type: object
+              properties:
+                owner:
+                  type: string
+                authorized:
+                  type: string
+
+    TicketEntry:
+      type: object
+      description: Retrieve a Ticket entry, which represents a sequence number set aside for future use.
+      properties:
+        ticket:
+          oneOf:
+            - type: string
+            - type: object
+              properties:
+                account:
+                  type: string
+                ticket_seq:
+                  type: integer
+
+    NFTPageEntry:
+      type: object
+      description: Return an NFT Page in its raw ledger format.
+      properties:
+        nft_page:
+          type: string
+
+    LedgerEntrySuccessResponse:
+      description: The response for a successful ledger_entry request, containing the requested ledger entry data.
+      allOf:
+        - $ref: '../base.yaml#/components/schemas/BaseSuccessResponse'
+        - type: object
+          properties:
+            result:
+              type: object
+              properties:
+                index:
+                  type: string
+                  description: The unique ID of this ledger entry.
+                ledger_index:
+                  type: integer
+                  description: The ledger index of the ledger that was used when retrieving this data.
+                node:
+                  type: object
+                  description: (Omitted if "binary":true specified.) Object containing the data of this ledger entry, according to the ledger format.
+                node_binary:
+                  type: string
+                  description: (Omitted unless "binary":true specified) The binary representation of the ledger object, as hexadecimal.
+                deleted_ledger_index:
+                  type: integer
+                  description: (Clio server only, returned if include_deleted parameter is set.) The ledger index where the ledger entry object was deleted.
+
+    LedgerEntryErrorResponse:
+      description: The response for an unsuccessful ledger_entry request, containing error information.
+      type: object
+      properties:
+        error:
+          type: string
+          oneOf:
+            - $ref: '../base.yaml#/components/schemas/UniversalErrorResponseCodes'
+            - enum:
+                - deprecatedFeature
+                - entryNotFound
+                - invalidParams
+                - lgrNotFound
+                - malformedAddress
+                - malformedCurrency
+                - malformedOwner
+                - malformedRequest
+                - unknownOption
+          description: >
+            * `deprecatedFeature` - The request specified a deprecated feature.
+            * `entryNotFound` - The requested ledger entry was not found in the ledger.
+            * `invalidParams` - One or more fields are specified incorrectly, or one or more required fields are missing.
+            * `lgrNotFound` - The ledger specified by the ledger_hash or ledger_index does not exist, or it does exist but the server does not have it.
+            * `malformedAddress` - The request specified an invalid address.
+            * `malformedCurrency` - The request specified an invalid currency.
+            * `malformedOwner` - The request specified an invalid owner.
+            * `malformedRequest` - The request was not formatted properly.
+            * `unknownOption` - The request specified an unknown option.
+        status:
+          type: string
+          enum:
+            - error
+        request:
+          $ref: '#/components/schemas/LedgerEntryRequest'
+      required:
+        - status
+        - error
+        - request

--- a/shared/requests/ledger_entry.yaml
+++ b/shared/requests/ledger_entry.yaml
@@ -90,6 +90,14 @@ components:
               type: string
             LockingChainIssue:
               $ref: '../base.yaml#/components/schemas/CurrencyWithoutAmount'
+          required:
+            - IssuingChainDoor
+            - IssuingChainIssue
+            - LockingChainDoor
+            - LockingChainIssue
+      required:
+        - bridge_account
+        - bridge
 
     DirectoryNodeEntry:
       type: object


### PR DESCRIPTION
This specification borrows content from the documentation webpage: https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/ledger-methods/ledger_entry#response-format

I'd like to see these [issues](https://github.com/XRPLF/xrpl-dev-portal/issues/2745) fixed in the main documentation site. We need to update the specification after that change.

As part of future work, I'd like to add unit test to validate the correctness of these models. More importantly, unit tests are absent for all the models relevant to the current prototype specification. We need to port tests from the client libraries into the code-generation repository to make up for the deficit.