### PR TITLE
Fix: Rename Path schema as PathStep 

### DIFF
--- a/shared/transactions/payment.yaml
+++ b/shared/transactions/payment.yaml
@@ -29,7 +29,7 @@ components:
           items:
             type: array
             items:
-              $ref: '#/components/schemas/Path'
+              $ref: '#/components/schemas/PathStep'
           description: '(Optional, auto-fillable) Array of payment paths to be used for this transaction. Must be omitted for XRP-to-XRP transactions.'
         SendMax:
           $ref: '../base.yaml#/components/schemas/CurrencyAmount'
@@ -62,8 +62,8 @@ components:
       required:
         - DeliverMax
 
-    Path:
-      $id: Path
+    PathStep:
+      $id: PathStep
       type: object
       properties:
         account:


### PR DESCRIPTION
rename the schema into PathStep -- maintains compatibility with xrpl-py and xrpl.js SDK

The existing client libraries refer to `Path` model as a list of `PathStep` values. The YAML specification needs to reflect similar organization.