### PR TITLE
ledger_entry RPC: insert required clause on object inputs

### DIFF
--- a/shared/requests/ledger_entry.yaml
+++ b/shared/requests/ledger_entry.yaml
@@ -71,6 +71,9 @@ components:
                   $ref: '../base.yaml#/components/schemas/CurrencyWithoutAmount'
                 asset2:
                   $ref: '../base.yaml#/components/schemas/CurrencyWithoutAmount'
+              required:
+                - asset
+                - asset2
 
     BridgeEntry:
       type: object
@@ -128,6 +131,9 @@ components:
                   type: string
                 seq:
                   type: integer
+              required:
+                - account
+                - seq
 
     OracleEntry:
       type: object
@@ -140,6 +146,9 @@ components:
               type: string
             oracle_document_id:
               type: integer
+          required:
+            - account
+            - oracle_document_id
 
     RippleStateEntry:
       type: object
@@ -156,6 +165,9 @@ components:
               maxItems: 2
             currency:
               type: string
+          required:
+            - accounts
+            - currency
 
     CheckEntry:
       type: object
@@ -177,6 +189,9 @@ components:
                   type: string
                 seq:
                   type: integer
+              required:
+                - owner
+                - seq
 
     PayChannelEntry:
       type: object
@@ -198,6 +213,9 @@ components:
                   type: string
                 authorized:
                   type: string
+              required:
+                - owner
+                - authorized
 
     TicketEntry:
       type: object
@@ -212,6 +230,9 @@ components:
                   type: string
                 ticket_seq:
                   type: integer
+              required:
+                - account
+                - ticket_seq
 
     NFTPageEntry:
       type: object


### PR DESCRIPTION
add required clause on all object inputs in ledger_entry RPC. This handles the conditionally required parameters in the input.

This PR addresses the concerns raises in this [comment](https://github.com/ripple/rippled-api-spec/pull/7#issuecomment-2356205620).

By mandating certain properties as `required` in the YAML specification, we can conditionally enforce their presence in inputs. Ex: If a user chooses to specify AMM entry as an object, both `asset` and `asset2` are required. Alternatively, if the `AMMID` is specified as a `string` type, then these fields are not mandatory.

Such validation checks can be now enforced.

