### PR TITLE
Add YAML spec validation checks for Payment transaction

### DIFF
--- a/shared/base.yaml
+++ b/shared/base.yaml
@@ -206,6 +206,7 @@ components:
         currency:
           type: string
           description: 'Arbitrary currency code for the token. Cannot be XRP.'
+          pattern: '^[a-z]{3}$'
         value:
           type: string
           pattern: '^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$'

--- a/shared/transactions/payment.yaml
+++ b/shared/transactions/payment.yaml
@@ -24,6 +24,7 @@ components:
         InvoiceID:
           type: string
           description: '(Optional) Arbitrary 256-bit hash representing a specific reason or identifier for this payment.'
+          maxLength: 256
         Paths:
           type: array
           items:


### PR DESCRIPTION
Certain properties pertaining to the Payment transaction can be validated based on length, regex etc. This PR aims to capture such opportunities.