### PR TITLE
fix: BaseRequest order and add some missing description

### DIFF
--- a/shared/base.yaml
+++ b/shared/base.yaml
@@ -194,6 +194,9 @@ components:
 
     CurrencyAmount:
       $id: CurrencyAmount
+      description: >
+        A CurrencyAmount is an object specifying a currency, a quantity of that currency, and the
+        counterparty (issuer) on the trustline that holds the value. For XRP, there is no counterparty.
       oneOf:
         - type: string
           description: 'The amount of XRP (drops), represented as a string.'
@@ -202,6 +205,7 @@ components:
     TokenAmount:
       $id: TokenAmount
       type: object
+      description: Specifies an amount of a (fungible) token.
       properties:
         currency:
           type: string

--- a/shared/requests/account_channels.yaml
+++ b/shared/requests/account_channels.yaml
@@ -9,8 +9,8 @@ components:
         Returns an AccountChannelsResponse.
       type: object
       allOf:
-        - $ref: '../base.yaml#/components/schemas/LookupByLedgerRequest'
         - $ref: '../base.yaml#/components/schemas/BaseRequest'
+        - $ref: '../base.yaml#/components/schemas/LookupByLedgerRequest'
       properties:
         account:
           type: string

--- a/shared/requests/account_info.yaml
+++ b/shared/requests/account_info.yaml
@@ -7,8 +7,8 @@ components:
         Returns an AccountInfoResponse
       type: object
       allOf:
-        - $ref: '../base.yaml#/components/schemas/LookupByLedgerRequest'
         - $ref: '../base.yaml#/components/schemas/BaseRequest'
+        - $ref: '../base.yaml#/components/schemas/LookupByLedgerRequest'
       properties:
         account:
           type: string
@@ -26,6 +26,7 @@ components:
 
     AccountRoot:
       type: object
+      description: An AccountRoot ledger entry type describes a single account, its settings, and XRP balance.
       properties:
         Account:
           type: string

--- a/shared/requests/account_lines.yaml
+++ b/shared/requests/account_lines.yaml
@@ -7,8 +7,8 @@ components:
         Returns an AccountLinesResponse
       type: object
       allOf:
-        - $ref: '../base.yaml#/components/schemas/LookupByLedgerRequest'
         - $ref: '../base.yaml#/components/schemas/BaseRequest'
+        - $ref: '../base.yaml#/components/schemas/LookupByLedgerRequest'
       properties:
         account:
           type: string

--- a/shared/requests/ledger_entry.yaml
+++ b/shared/requests/ledger_entry.yaml
@@ -37,8 +37,8 @@ components:
       description: The ledger_entry method returns a single ledger entry from the XRP Ledger in its raw format. All information retrieved is relative to a particular version of the ledger.
       type: object
       allOf:
-        - $ref: '../base.yaml#/components/schemas/LookupByLedgerRequest'
         - $ref: '../base.yaml#/components/schemas/BaseRequest'
+        - $ref: '../base.yaml#/components/schemas/LookupByLedgerRequest'
         - $ref: '#/components/schemas/BaseLedgerEntryRequest'
         - $ref: '#/components/schemas/LedgerEntryRequestOptions'
 

--- a/shared/transactions/payment.yaml
+++ b/shared/transactions/payment.yaml
@@ -64,6 +64,7 @@ components:
 
     PathStep:
       $id: PathStep
+      description: A PathStep represents an individual step along a Path.
       type: object
       properties:
         account:


### PR DESCRIPTION
This PR:
- Switch BaseRequest to top of `allOf` of all request definition.
- Add some missing description